### PR TITLE
keep crlf out of the repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This commit avoids mixing up CR+LF (Windows style) and LF (Unix style) line endings.

On Windows, it commits Unix Style and checks out Windows Style.

On FreeBSD, Linux and macOS it commits Unix style and checks out Unix Style.